### PR TITLE
Fix GitHub Actions workflows to prevent PR previews from overriding main branch

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,21 +9,18 @@ on:
       - ".gitignore"
 
 permissions:
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
   group: gh-pages
   cancel-in-progress: false
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - name: configure pages
-        uses: actions/configure-pages@v5
       - name: setup node
         uses: actions/setup-node@v4
         with:
@@ -32,17 +29,10 @@ jobs:
         run: npm install --global @antora/cli@3.1 @antora/site-generator@3.1
       - name: antora generate
         run: antora generate default-site.yml --stacktrace
-      - name: upload pages artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: deploy to github pages
+        uses: peaceiris/actions-gh-pages@v3
         with:
-          path: www
-  deploy:
-    needs: build
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
-    - name: deploy github pages
-      id: deployment
-      uses: actions/deploy-pages@v4
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./www
+          keep_files: true
+          enable_jekyll: false

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -8,14 +8,34 @@ jobs:
   cleanup-preview:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pages: write
-      id-token: write
+      contents: write
       pull-requests: write
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+    
+    - name: Checkout gh-pages branch
+      uses: actions/checkout@v4
+      with:
+        ref: gh-pages
+        path: gh-pages-content
+    
+    - name: Remove PR preview directory
+      run: |
+        if [ -d "gh-pages-content/pr-${{ github.event.pull_request.number }}" ]; then
+          rm -rf gh-pages-content/pr-${{ github.event.pull_request.number }}
+          echo "Removed preview directory for PR #${{ github.event.pull_request.number }}"
+        else
+          echo "Preview directory for PR #${{ github.event.pull_request.number }} not found"
+        fi
+    
+    - name: Deploy cleanup to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./gh-pages-content
+        enable_jekyll: false
     
     - name: Get current date
       id: date
@@ -30,11 +50,11 @@ jobs:
           
           This PR has been ${{ github.event.pull_request.merged && 'merged' || 'closed' }}. 
           
-          The documentation preview for PR #${{ github.event.pull_request.number }} has been scheduled for cleanup.
+          The documentation preview for PR #${{ github.event.pull_request.number }} has been cleaned up successfully.
           
           **📋 Cleanup Details:**
           - **PR Number:** #${{ github.event.pull_request.number }}
           - **Status:** ${{ github.event.pull_request.merged && 'Merged' || 'Closed' }}
           - **Cleanup Time:** ${{ steps.date.outputs.date }}
           
-          *Note: Preview artifacts and deployments will be automatically cleaned up according to retention policies.* 
+          *The preview directory has been removed from GitHub Pages.* 

--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -8,14 +8,9 @@ on:
 jobs:
   build-and-deploy-preview:
     permissions:
-      contents: read
-      pages: write
-      id-token: write
+      contents: write
       pull-requests: write
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}pr-${{ github.event.number }}/
     
     steps:
     - name: Checkout repository
@@ -40,22 +35,14 @@ jobs:
         echo "Building Antora documentation..."
         antora --stacktrace default-site.yml
     
-    - name: Create PR-specific directory
-      run: |
-        mkdir -p preview/pr-${{ github.event.number }}
-        cp -r www/* preview/pr-${{ github.event.number }}/
-    
-    - name: Setup Pages
-      uses: actions/configure-pages@v4
-    
-    - name: Upload to GitHub Pages
-      uses: actions/upload-pages-artifact@v3
+    - name: Deploy PR Preview to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
       with:
-        path: preview/
-    
-    - name: Deploy to GitHub Pages
-      id: deployment
-      uses: actions/deploy-pages@v4
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./www
+        destination_dir: pr-${{ github.event.number }}
+        keep_files: true
+        enable_jekyll: false
     
     - name: Get current date
       id: date
@@ -86,7 +73,7 @@ jobs:
           - **Build Time:** ${{ steps.date.outputs.date }}
           
           **🌐 Live Preview:**
-          [**🔗 View Documentation Preview**](${{ steps.deployment.outputs.page_url }}pr-${{ github.event.number }}/)
+          [**🔗 View Documentation Preview**](https://redhat-ads-tech.github.io/rhads-enablement-l3/pr-${{ github.event.number }}/)
           
           **📥 Alternative - Download Artifact:**
           You can also download the generated documentation from the [Actions tab](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).


### PR DESCRIPTION
## Problem

The current GitHub Actions setup has a conflict where PR preview deployments completely overwrite the main branch deployment, causing the main site at https://redhat-ads-tech.github.io/rhads-enablement-l3/ to return 404 errors when PR previews are active.

## Root Cause

Both workflows were using the GitHub Pages environment incorrectly:
- Main branch workflow used `actions/deploy-pages@v4` to deploy to the root
- PR preview workflow used `actions/deploy-pages@v4` to deploy a `preview/` directory structure, completely overwriting the main branch content

## Solution

Modified all three workflows to use `peaceiris/actions-gh-pages@v3` with proper configuration:

### 1. Main Branch Workflow (`gh-pages.yml`)
- Uses `keep_files: true` to preserve existing PR preview directories
- Deploys main content to root without affecting PR previews

### 2. PR Preview Workflow (`pr-preview-deploy.yml`)  
- Uses `destination_dir: pr-${{ github.event.number }}` to deploy to subdirectories
- Uses `keep_files: true` to avoid overwriting main content
- Deploys PR previews to `pr-X/` without touching main site

### 3. PR Cleanup Workflow (`pr-preview-cleanup.yml`)
- Now actually removes PR preview directories when PRs are closed
- Properly cleans up `pr-X/` directories from gh-pages branch

## Benefits

- ✅ No more conflicts between main branch and PR preview deployments
- ✅ Main site remains accessible at all times
- ✅ PR previews work correctly at `pr-X/` subdirectories
- ✅ Automatic cleanup of PR directories when PRs close
- ✅ Consistent deployment approach across all workflows

## Testing

After this PR is merged, the main branch workflow will restore the main site deployment while preserving any existing PR preview directories.